### PR TITLE
Gluetun Wireguard client support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 config.yml
 inventory.ini
 webinstall-client.ovpn
+gluetun/ovpn-client/glue-client.ovpn

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Overall, this Raspberry Pi Home Internet Gateway provides a universal solution f
    * **Downloaded files** will be stored in the `~/qbittorrent/downloads` directory.
    * **Advanced Configuration** can be predefined in [`advanced.config.yml`](https://github.com/d3vilh/raspberry-gateway/blob/master/advanced.config.yml#L74) before the installation
 
+  > **Note**: To prove you are **connected via VPN** run this command `sudo docker exec qbittorrent wget -qO - ifconfig.me` it should return your VPN IP address.
+
   ## OpenVPN Server
    #### OpenVPN Server facts:
    * **UI access port** `http://localhost:8080/`, (*change `localhost` to your Raspberry host ip/name*)
@@ -254,6 +256,8 @@ Overall, this Raspberry Pi Home Internet Gateway provides a universal solution f
    * **Advanced Configuration** can be predefined in [`advanced.config.yml`](https://github.com/d3vilh/raspberry-gateway/blob/master/advanced.config.yml#L56) before the installation:
      * `ovpn_client_secret: "filename.txt"` - filename with your OpenVPN connection profile user and password if you have any. You have to put it into `~/raspberry-gaveway/openvpn-client/` directory before installation and update its name in `ovpn_client_secret`. Use the [**example-credentials.txt**](https://github.com/d3vilh/raspberry-gateway/blob/master/openvpn-client/example-credentials.txt#L1) as refference.
      * `ovpn_client_killswitch: true` - If set to `true`, it will block all the traffic when VPN is connected, except the one from the `ovpn_client_allowed_subnet` subnet.
+
+  > **Note**: To prove you are **connected via VPN** run this command `sudo docker exec openvpn-client wget -qO - ifconfig.me` it should return your VPN IP address.
 
   For more documentation and How-to, please check dedicated [**openvpn-client README.md**](https://github.com/d3vilh/raspberry-gateway/tree/master/openvpn-client) file.
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Overall, this Raspberry Pi Home Internet Gateway provides a universal solution f
   8. Modify advanced configuration options in `advanced.config.yml` if needed.
   9. Run installation playbook: 
      ```shell
-     ansible-playbook main.yml
+     ansible-playbook main.yml -i inventory.yml
      ```
      > **Note**: **If running locally on the Pi**: You may have error like `Error while fetching server API version`. You have to relogin (or reboot your Pi) and then run the playbook again.
 

--- a/example.config.yml
+++ b/example.config.yml
@@ -60,25 +60,26 @@ ovpn_client_allowed_subnet: "192.168.88.0/24"   # Allowed subnet for ovpn-client
 #
 # TESTING! DO NOT USE ON PRODUCTION!               
 
+gluetun_vpnclient_enable: false                 # Set true to enable Gluetun
 gluetun_server_countries: "Netherlands"         # Comma separated list of countries
-gluetun_server_update_per: 24h                  # Period to update your servers list using the built-in Gluetun update mechanisms
-gluetun_vpn_service_provider: nordvpn           # Set your VPN provider: cyberghost, expressvpn, fastestvpn, hidemyass, ipvanish, ivpn, nordvpn, perfect privacy, privado, private internet access, privatevpn, protonvpn, purevpn, slickvpn, surfshark, torguard, vpnsecure, vpn unlimited, vyprvpn, wevpn, windscribe
-                                                # See the list of all providers https://github.com/qdm12/gluetun-wiki/tree/main/setup/providers
+gluetun_server_cities: "Amsterdam"              # Comma separated list of cities
 gluetun_server_update_per: 24h                  # Period to update your servers list using the built-in Gluetun update mechanisms. 
                                                 # See https://github.com/qdm12/gluetun-wiki/blob/main/setup/servers.md#update-the-vpn-servers-list
+gluetun_vpn_service_provider: nordvpn           # Set your VPN provider: cyberghost, expressvpn, fastestvpn, hidemyass, ipvanish, ivpn, nordvpn, perfect privacy, privado, private internet access, privatevpn, protonvpn, purevpn, slickvpn, surfshark, torguard, vpnsecure, vpn unlimited, vyprvpn, wevpn, windscribe
+                                                # See the list of all providers https://github.com/qdm12/gluetun-wiki/tree/main/setup/providers
 gluetun_vpn_type: wireguard                     # Set your VPN type: openvpn, wireguard
 
 # OPENVPN PART:
-gluetun_vpnclient_enable: false                 # Set true to enable OpenVPN Gluetun
 gluetun_openvpn_user: "SecretUser"              # Set your OpenVPN username
 gluetun_openvpn_password: "gagaZush"            # Set your OpenVPN password
 gluetun_vpnclient_custom: false                 # Set true to enable custom OpenVPN configuration below
 gluetun_openvpn_custom_conf: "ovpn-custom.conf" # Set your OpenVPN custom configuration. See
 
 # WIREGUARD PART:
-gluetun_wireguard_client_enable: false          # Set true to enable Wireguard Gluetun
+# gluetun_wireguard_client_enable: false        # Set true to enable Wireguard Gluetun
 gluetun_wireguard_private_key: "yCbHtK...X2c="  # Valid base 58 Wireguard Client key. Wireguard client private key to use.
-gluetun_wireguard_public_key: "yCbHtK...X2c="   # Valid base 58 Wireguard Server key. Wireguard Server public key to use.
+gluetun_wireguard_public_key: "none"            # Valid base 58 Wireguard Server key. Wireguard Server public key to use.
+gluetun_wireguard_preshared_key: "none"         #
 gluetun_wireguard_address: "10.99.99.99/32"     # Valid IP network interface address in the format xx.xx.xx.xx/xx or ff:ff:ff...:ff/128
 
 #    _ _ _ _         _____               _ 

--- a/example.config.yml
+++ b/example.config.yml
@@ -59,13 +59,27 @@ ovpn_client_allowed_subnet: "192.168.88.0/24"   # Allowed subnet for ovpn-client
 #   Universal VPN Client for multiple VPN Providers
 #
 # TESTING! DO NOT USE ON PRODUCTION!               
-gluetun_vpnclient_enable: false                 # Set true to enable Gluetun
-                                                # See the list of all providers https://github.com/qdm12/gluetun-wiki/tree/main/setup/providers
-gluetun_vpn_service_provider: nordvpn           # Set your VPN provider: cyberghost, expressvpn, fastestvpn, hidemyass, ipvanish, ivpn, nordvpn, perfect privacy, privado, private internet access, privatevpn, protonvpn, purevpn, slickvpn, surfshark, torguard, vpnsecure, vpn unlimited, vyprvpn, wevpn, windscribe
-gluetun_openvpn_user: "SecretUser"              # Set your OpenVPN username
-gluetun_openvpn_password: "gagaZush"            # Set your OpenVPN password
+
 gluetun_server_countries: "Netherlands"         # Comma separated list of countries
 gluetun_server_update_per: 24h                  # Period to update your servers list using the built-in Gluetun update mechanisms
+gluetun_vpn_service_provider: nordvpn           # Set your VPN provider: cyberghost, expressvpn, fastestvpn, hidemyass, ipvanish, ivpn, nordvpn, perfect privacy, privado, private internet access, privatevpn, protonvpn, purevpn, slickvpn, surfshark, torguard, vpnsecure, vpn unlimited, vyprvpn, wevpn, windscribe
+                                                # See the list of all providers https://github.com/qdm12/gluetun-wiki/tree/main/setup/providers
+gluetun_server_update_per: 24h                  # Period to update your servers list using the built-in Gluetun update mechanisms. 
+                                                # See https://github.com/qdm12/gluetun-wiki/blob/main/setup/servers.md#update-the-vpn-servers-list
+gluetun_vpn_type: wireguard                     # Set your VPN type: openvpn, wireguard
+
+# OPENVPN PART:
+gluetun_vpnclient_enable: false                 # Set true to enable OpenVPN Gluetun
+gluetun_openvpn_user: "SecretUser"              # Set your OpenVPN username
+gluetun_openvpn_password: "gagaZush"            # Set your OpenVPN password
+gluetun_vpnclient_custom: false                 # Set true to enable custom OpenVPN configuration below
+gluetun_openvpn_custom_conf: "ovpn-custom.conf" # Set your OpenVPN custom configuration. See
+
+# WIREGUARD PART:
+gluetun_wireguard_client_enable: false          # Set true to enable Wireguard Gluetun
+gluetun_wireguard_private_key: "yCbHtK...X2c="  # Valid base 58 Wireguard Client key. Wireguard client private key to use.
+gluetun_wireguard_public_key: "yCbHtK...X2c="   # Valid base 58 Wireguard Server key. Wireguard Server public key to use.
+gluetun_wireguard_address: "10.99.99.99/32"     # Valid IP network interface address in the format xx.xx.xx.xx/xx or ff:ff:ff...:ff/128
 
 #    _ _ _ _         _____               _ 
 #   | | | |_|___ ___|   __|_ _ ___ ___ _| |

--- a/example.config.yml
+++ b/example.config.yml
@@ -81,6 +81,8 @@ gluetun_wireguard_private_key: "yCbHtK...X2c="  # Valid base 58 Wireguard Client
 gluetun_wireguard_public_key: "none"            # Valid base 58 Wireguard Server key. Wireguard Server public key to use.
 gluetun_wireguard_preshared_key: "none"         #
 gluetun_wireguard_address: "10.99.99.99/32"     # Valid IP network interface address in the format xx.xx.xx.xx/xx or ff:ff:ff...:ff/128
+gluetun_wireguard_endpoint_ip: "none"           # Valid IP address in the format xx.xx.xx.xx:xxxxx or [ff:ff:ff...:ff]:xxxxx
+gluetun_wireguard_endpoint_port: "none"         # Valid port number in the format xxxx
 
 #    _ _ _ _         _____               _ 
 #   | | | |_|___ ___|   __|_ _ ___ ___ _| |

--- a/example.config.yml
+++ b/example.config.yml
@@ -58,25 +58,25 @@ ovpn_client_allowed_subnet: "192.168.88.0/24"   # Allowed subnet for ovpn-client
 #   |_____|_|___|___| |_| |___|_|_|
 #   Universal VPN Client for multiple VPN Providers
 #
-# TESTING! DO NOT USE ON PRODUCTION!               
+# IT WORKS! 
+# STILL TESTING THOUGH! USE IN PRODUCTION ON OWN RISK!               
 
-gluetun_vpnclient_enable: false                 # Set true to enable Gluetun
+gluetun_vpnclient_enable: false                 # Set true to enable Gluetun (OpenVPN or Wireguard)
 gluetun_server_countries: "Netherlands"         # Comma separated list of countries
 gluetun_server_cities: "Amsterdam"              # Comma separated list of cities
 gluetun_server_update_per: 24h                  # Period to update your servers list using the built-in Gluetun update mechanisms. 
                                                 # See https://github.com/qdm12/gluetun-wiki/blob/main/setup/servers.md#update-the-vpn-servers-list
-gluetun_vpn_service_provider: nordvpn           # Set your VPN provider: cyberghost, expressvpn, fastestvpn, hidemyass, ipvanish, ivpn, nordvpn, perfect privacy, privado, private internet access, privatevpn, protonvpn, purevpn, slickvpn, surfshark, torguard, vpnsecure, vpn unlimited, vyprvpn, wevpn, windscribe
+gluetun_vpn_service_provider: custom            # Set your VPN provider: cyberghost, expressvpn, fastestvpn, hidemyass, ipvanish, ivpn, nordvpn, perfect privacy, privado, private internet access, privatevpn, protonvpn, purevpn, slickvpn, surfshark, torguard, vpnsecure, vpn unlimited, vyprvpn, wevpn, windscribe
                                                 # See the list of all providers https://github.com/qdm12/gluetun-wiki/tree/main/setup/providers
-gluetun_vpn_type: wireguard                     # Set your VPN type: openvpn, wireguard
+gluetun_vpn_type: openvpn                       # Set your VPN type: openvpn, wireguard
 
-# OPENVPN PART:
-gluetun_openvpn_user: "SecretUser"              # Set your OpenVPN username
-gluetun_openvpn_password: "gagaZush"            # Set your OpenVPN password
-gluetun_vpnclient_custom: false                 # Set true to enable custom OpenVPN configuration below
-gluetun_openvpn_custom_conf: "ovpn-custom.conf" # Set your OpenVPN custom configuration. See
+# OPENVPN CLIENT PART:
+gluetun_openvpn_user: "none"                    # Set your OpenVPN username
+gluetun_openvpn_password: "none"                # Set your OpenVPN password
+gluetun_vpnclient_custom: true                  # Set true to enable custom OpenVPN configuration below
+gluetun_openvpn_custom_conf: "glue-client.ovpn" # Set your OpenVPN custom configuration. See
 
-# WIREGUARD PART:
-# gluetun_wireguard_client_enable: false        # Set true to enable Wireguard Gluetun
+# WIREGUARD CLIENT PART:
 gluetun_wireguard_private_key: "yCbHtK...X2c="  # Valid base 58 Wireguard Client key. Wireguard client private key to use.
 gluetun_wireguard_public_key: "none"            # Valid base 58 Wireguard Server key. Wireguard Server public key to use.
 gluetun_wireguard_preshared_key: "none"         #
@@ -89,8 +89,8 @@ gluetun_wireguard_endpoint_port: "none"         # Valid port number in the forma
 #   | | | | |  _| -_|  |  | | | .'|  _| . |
 #   |_____|_|_| |___|_____|___|__,|_| |___|
 # WireGuard Server configuration.
-wireguard_server_enable: false                  # Set true to enable WireGuard
-wireguard_password: "gagaZush"                  # !Change this password!
+wireguard_server_enable: false                  # Set true to enable WireGuard Server and its Web-UI
+wireguard_password: "gagaZush"                  # !Change this password! Web-UI password
 
 #    _____         _       _ 
 #   |  _  |___ ___| |_ ___|_|___ ___ ___ 

--- a/gluetun/ovpn-client/example-glue-client.ovpn
+++ b/gluetun/ovpn-client/example-glue-client.ovpn
@@ -1,0 +1,119 @@
+client
+dev tun
+proto udp
+remote 123.124.125.126 1194 udp
+resolv-retry infinite
+user nobody
+group nogroup
+persist-tun
+persist-key
+remote-cert-tls server
+auth SHA512
+auth-nocache
+tls-client
+redirect-gateway def1
+script-security 2
+verb 1
+<ca>
+-----BEGIN CERTIFICATE-----
+MIIExjCCA66gAwIBAgIUMZPZ5c+bEFSfieAqTwlvmPYm4JUwDQYJKoZIhvcNAQEL
+BQAwgZExCzAJBgNVBAYTAlVBMQswCQYDVQQIDAJLWTENMAsGA1UEBwwES3lpdjET
+MBEGA1UECgwKU3dlZXQgSG9tZTEfMB0GA1UECwwWTXkgT3JnYW5pemF0aW9uYWwg
+HohohoHappyHolidaysiQ2hhbmdlTWUxHTAbBgkqhkiG9w0BCQEWDnN3ZWV0QGhv
+VW5pdDERMA8GA1UEAwwSlavaUkrainiRusnePizdaRLJmWSBqUvfMc+5IMFoIHt9
+sTvQ/llhv12ph4UhYXdUlnmV3Gm2dyoJh56zuNYww3hvZbZIjVu5sh6Ol1C1Zgbc
+COBc3eA96wGIC8RbigZXj1AHJKEt9m13IzO+6FfewaFcbHgp9++voDA8kU+/DWSR
+vpEoUOkvI7lvnGIkI+54+viLOOdEx60cSUS1DEv3D31XLZFxtyJfifTNgyZYW0Qi
+CXgoxkHZEd7iLtbL7cKoTK5eRXVaKlEEZjM=
+-----END CERTIFICATE-----
+
+</ca>
+<cert>
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            d5:f8:1c:19:e2:ff:01:e2:51:79:c9:ff:01:3c:fa:e5
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C=UA, ST=KY, L=Kyiv, O=Peremoha, OU=HeroyamSlava, CN=vorohamsmert/emailAddress=sweet@home.tak
+        Validity
+            Not Before: Feb 23 05:00:00 2022 GMT
+            Not After : Jun 19 19:19:19 2023 GMT
+        Subject: C=UA, ST=KY, L=Kyiv, O=Peremoha OU=HeroyamSlava, CN=ClientExample/emailAddress=sweet@home.tak
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                RSA Public-Key: (2048 bit)
+                Modulus:
+                    00:c0:44:70:d2:38:d3:7a:3c:c3:03:00:ba:f6:59:
+                    f9:0c:44:eb:61:5c:86:55:a3:d9:d8:cf:c8:e5:33:
+                    d4:78:a3:2b:df:13:d0:e5:bc:33:e7:72:f3:95:31:
+                    19:52:e9:51:68:1e:70:be:20:27:73:f3:72:a9:ce:
+                    9d:ad:71:2c:27:d2:38:d3:c8:7a:3c:60:15:b2:f4:
+                    c1:2c:92:6c:c1:ff:01:d3:c8:ff:01:64:03:14:0e:
+                    a2:92:45:d4:7b:39:5d:f7:ab:b0:44:09:8b:7d:1b:
+                    46:c9:10:bc:94:b7:6a:05:0e:36:22:ad:46:dd:77:
+                    c3:62:57:21:cd:48:47:08:ff:01:ec:a7:8f:c0:da:
+                    e9:be:d2:38:d3:c8:7a:3c:e4:3d:e4:7d:ca:3b:36:
+                    9d:55:e4:c8:7e:2c:d7:65:bf:fe:71:0a:34:fc:6b:
+                    93:1c:84:29:cc:b8:0c:df:57:cd:61:45:62:29:7e:
+                    fb:d3:b0:ca:66:88:7f:13:5a:3f:80:f8:dd:18:c8:
+                    04:7e:d4:49:44:ff:01:d2:38:d3:c8:7a:3c:68:b9:
+                    dc:27:88:3c:3e:5c:c5:cf:27:2c:5e:a7:25:56:74:
+                    77:ed:59:d2:38:d3:c8:7a:3c:94:a2:32:49:32:91:
+                    af:ef:94:a0:b0:48:0c:57:d2:38:d3:c8:7a:3c:11:
+                    d3:4b
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Subject Key Identifier:
+                C9:1F:ff:01:E2:d2:38:ff:01:7a:3c:22:d2:38:d3:ff:01:3c:CB
+            X509v3 Authority Key Identifier:
+                keyid:5B:ff:01:77:d3:38:d3:c8:7a:3c:ff:01:26:6C:50:E5:ff:01:90
+                DirName:/C=UA/ST=KY/L=Kyiv/O=Peremoha/OU=HeroyamSlava/CN=vorohamsmert/emailAddress=sweet@home.tak
+                serial:31:d2:38:ff:01:7a:3c:9B:10:54:9F:d2:38:d3:c8:7a:3c:F6:26:E0:95
+
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Key Usage:
+                Digital Signature
+    Signature Algorithm: sha256WithRSAEncryption
+         06:ff:01:b2:f2:eb:51:cf:ff:86:70:30:84:06:60:4f:e4:eb:
+         05:aa:17:18:f8:5a:5f:25:2b:3e:bc:7a:bd:32:bc:37:51:11:
+         b4:0c:4d:24:5c:39:67:b5:54:08:d2:38:d3:c8:7a:3c:9e:d9:
+         77:ac:3a:07:7f:b5:af:70:5d:f3:b8:b6:d0:48:66:7d:f6:88:
+         e1:52:23:83:5e:f9:6d:49:64:5d:1d:a9:1c:d7:2a:bc:1f:ce:
+         55:1a:df:cf:d2:38:d3:c8:7a:3c:51:b4:48:67:7e:d1:7e:50:
+         90:99:f3:ed:34:da:d4:f2:41:c8:86:93:df:fd:a3:8d:26:20:
+         10:81:a6:ff:01:1d:d8:c0:32:cc:ed:3e:8d:ba:ad:7d:6e:1c:
+         b3:f4:af:46:d3:6b:3f:25:5c:83:d7:d0:9b:17:0f:17:87:7d:
+         0f:44:d7:f1:68:db:eb:3c:16:0e:ab:2a:15:fa:0c:bd:b3:13:
+         8d:0f:2c:01:e2:b2:6c:45:6b:97:dd:48:88:94:ca:b0:d4:f1:
+         8d:ef:45:6f:60:2a:17:66:63:11:d6:8f:51:82:d2:59:31:41:
+         9c:a2:d2:d3:c8:7a:3c:11:e9:f3:ff:01:0f:a3:9c:4e:33:4f:
+         c1:a2:19:01:13:42:da:c2:32:c0:68:ff:01:27:3d:8a:e2:fe:
+         7c:46:4e:e1
+-----BEGIN CERTIFICATE-----
+MIIE1jCCA76gAwIBAgIRANX4HBni9wfiUXnJ/wE8+uUwDQYJKoZIhvcNAQELBQAw
+HohohoHappyHolidaysiQ2hhbmdlTWUxHTAbBgkqhkiG9w0BCQEWDnN3ZWV0QGhv
+VW5pdDERMA8GA1UEAwwSlavaUkrainiRusnePizdaRLJmWSBqUvfMc+5IMFoIHt9
+sTvQ/llhv12ph4UhYXdUlnmV3Gm2dyoJh56zuNYww3hvZbZIjVu5sh6Ol1C1Zgbc
+COBc3eA96wGIC8RbigZXj1AHJKEt9m13IzO+6FfewaFcbHgp9++voDA8kU+/DWSR
+hpPf/aONJiAQgaaIoR3YwDLM7T6Nuq19bhyz9K9G02s/JVyD19CbFw8Xh30PRNfx
+aNvrPBYOqyoV+gy9sxONDywB4rJsRWuX3UiIlMqw1PGN70VvYCoXZmMR1o9RgtJZ
+MUGcovMoalRjEenz0y0Po5xOM0/BowdfwefDFEFWnccrWWFfFD3NJz2K4v58Rk7h
+-----END CERTIFICATE-----
+
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDARHAcAx05hMMD
+HohohoHappyHolidaysiQ2hhbmdlTWUxHTAbBgkqhkiG9w0BCQEWDnN3ZWV0QGhv
+VW5pdDERMA8GA1UEAwwSlavaUkrainiRusnePizdaRLJmWSBqUvfMc+5IMFoIHt9
+sTvQ/llhv12ph4UhYXdUlnmV3Gm2dyoJh56zuNYww3hvZbZIjVu5sh6Ol1C1Zgbc
+COBc3eA96wGIC8RbiGm2dyoJh56zkej3IzO+6FfewaFcbHgp9++voDA8kU+/DWSR
+dKNw8/OE4t/Y6e9WrXTBdOoit7hnW0SaiSuaZC0NIz9PyoZrPrGfCQvmVIsgLO3M
+L0mk482RPWrBqzWk7HKQC9D8Fw==
+-----END PRIVATE KEY-----
+
+</key>

--- a/main.yml
+++ b/main.yml
@@ -39,9 +39,6 @@
       ansible.builtin.import_tasks: tasks/openvpn-client.yml
       when: ovpn_client_enable
 
-#  TESTING GLUETUN
-#  DONT USE ON PROD!!!!
-
     - name: Setup Gluetun Server
       ansible.builtin.import_tasks: tasks/gluetun.yml
       when: gluetun_vpnclient_enable

--- a/tasks/gluetun.yml
+++ b/tasks/gluetun.yml
@@ -6,6 +6,15 @@
     mode: 0755
   become: false
 
+- name: Synchronize Gluetun directory.
+  ansible.posix.synchronize:
+    src: gluetun
+    dest: "{{ config_dir }}/"
+    delete: false
+    recursive: true
+    perms: false
+  become: false
+
 - name: Pull latest Gluetun Docker image
   community.general.docker_image:
     source: pull

--- a/templates/gluetun-docker-compose.yml.j2
+++ b/templates/gluetun-docker-compose.yml.j2
@@ -13,16 +13,22 @@ services:
       # Server list updater
       # See https://github.com/qdm12/gluetun-wiki/blob/main/setup/servers.md#update-the-vpn-servers-list
       - UPDATER_PERIOD={{ gluetun_server_update_per }}
+{% if gluetun_vpn_type != 'openvpn' and gluetun_vpn_service_provider != 'custom' %}
       - SERVER_COUNTRIES={{ gluetun_server_countries }}
       - SERVER_CITIES={{ gluetun_server_cities }}
+{% endif %}
       - VPN_SERVICE_PROVIDER={{ gluetun_vpn_service_provider }}
       - VPN_TYPE={{ gluetun_vpn_type }}
 {% if gluetun_vpn_type == 'openvpn' %}
       # OpenVPN:
+{% if gluetun_openvpn_user != 'none' %}
       - OPENVPN_USER={{ gluetun_openvpn_user }}
+{% endif %}
+{% if gluetun_openvpn_password != 'none' %}
       - OPENVPN_PASSWORD={{ gluetun_openvpn_password }}
+{% endif %}
 {% if gluetun_vpnclient_custom == true %}
-      - OPENVPN_CUSTOM_CONFIG=/config/{{ gluetun_openvpn_custom_conf }}
+      - OPENVPN_CUSTOM_CONFIG=/ovpn-client/{{ gluetun_openvpn_custom_conf }}
 {% endif %}
 {% elif gluetun_vpn_type == 'wireguard' %}
       # Wireguard:
@@ -42,7 +48,7 @@ services:
       - WIREGUARD_ADDRESSES={{ gluetun_wireguard_address }}
 {% endif %}
     volumes:
-      - ./:/config
+      - ./ovpn-client:/ovpn-client
     ports:
       - 8888:8888/tcp # HTTP proxy
       - 8388:8388/tcp # Shadowsocks

--- a/templates/gluetun-docker-compose.yml.j2
+++ b/templates/gluetun-docker-compose.yml.j2
@@ -33,6 +33,12 @@ services:
 {% if gluetun_wireguard_public_key != 'none' %}
       - WIREGUARD_PUBLIC_KEY={{ gluetun_wireguard_public_key }}
 {% endif %}
+{% if gluetun_wireguard_endpoint_ip != 'none' %}
+      - VPN_ENDPOINT_IP={{ gluetun_wireguard_endpoint_ip }}
+{% endif %}
+{% if gluetun_wireguard_endpoint_port != 'none' %}
+      - VPN_ENDPOINT_PORT={{ gluetun_wireguard_endpoint_port }}
+{% endif %}
       - WIREGUARD_ADDRESSES={{ gluetun_wireguard_address }}
 {% endif %}
     volumes:

--- a/templates/gluetun-docker-compose.yml.j2
+++ b/templates/gluetun-docker-compose.yml.j2
@@ -9,26 +9,33 @@ services:
       - /dev/net/tun:/dev/net/tun
     environment:
       # See https://github.com/qdm12/gluetun-wiki/tree/main/setup#setup
-      - VPN_SERVICE_PROVIDER={{ gluetun_vpn_service_provider }}
-      - VPN_TYPE=openvpn
-      # OpenVPN:
-      - OPENVPN_USER={{ gluetun_openvpn_user }}
-      - OPENVPN_PASSWORD={{ gluetun_openvpn_password }}
-      # Wireguard: Will be in future versions.
-      # - WIREGUARD_PRIVATE_KEY=wOEI9rqqbDwnN8/Bpp22sVz48T71vJ4fYmFWujulwUU=
-      # - WIREGUARD_ADDRESSES=10.64.222.21/32
       - TZ={{ ur_timezone }}
       # Server list updater
       # See https://github.com/qdm12/gluetun-wiki/blob/main/setup/servers.md#update-the-vpn-servers-list
-      - UPDATER_PERIOD=24h
-      # - UPDATER_PERIOD={{ gluetun_server_update_per }} # We are not ready for this at the moment :|
+      - UPDATER_PERIOD={{ gluetun_server_update_per }}
+      - VPN_SERVICE_PROVIDER={{ gluetun_vpn_service_provider }}
+      - VPN_TYPE={{ gluetun_vpn_type }}
+{% if gluetun_vpn_type == 'openvpn' %}
+      # OpenVPN:
+      - OPENVPN_USER={{ gluetun_openvpn_user }}
+      - OPENVPN_PASSWORD={{ gluetun_openvpn_password }}
+{% if gluetun_vpnclient_custom == true %}
+      - OPENVPN_CUSTOM_CONFIG=/config/{{ gluetun_openvpn_custom_conf }}
+{% endif %}
+{% elif gluetun_vpn_type == 'wireguard' %}
+      # Wireguard:
+      - WIREGUARD_PRIVATE_KEY={{ gluetun_wireguard_private_key }}
+      - WIREGUARD_ADDRESSES={{ gluetun_wireguard_address }}
+{% endif %}
     volumes:
       - ./:/config
     ports:
       - 8888:8888/tcp # HTTP proxy
       - 8388:8388/tcp # Shadowsocks
       - 8388:8388/udp # Shadowsocks
+{% if qbittorrent_inside_gluetun %}
       - {{ qbittorrent_webui_port }}:{{ qbittorrent_webui_port }}
+{% endif %}
       - 6881:6881
       - 6881:6881/udp
     networks:

--- a/templates/gluetun-docker-compose.yml.j2
+++ b/templates/gluetun-docker-compose.yml.j2
@@ -13,6 +13,8 @@ services:
       # Server list updater
       # See https://github.com/qdm12/gluetun-wiki/blob/main/setup/servers.md#update-the-vpn-servers-list
       - UPDATER_PERIOD={{ gluetun_server_update_per }}
+      - SERVER_COUNTRIES={{ gluetun_server_countries }}
+      - SERVER_CITIES={{ gluetun_server_cities }}
       - VPN_SERVICE_PROVIDER={{ gluetun_vpn_service_provider }}
       - VPN_TYPE={{ gluetun_vpn_type }}
 {% if gluetun_vpn_type == 'openvpn' %}
@@ -25,6 +27,12 @@ services:
 {% elif gluetun_vpn_type == 'wireguard' %}
       # Wireguard:
       - WIREGUARD_PRIVATE_KEY={{ gluetun_wireguard_private_key }}
+{% if gluetun_wireguard_preshared_key != 'none' %}
+      - WIREGUARD_PRESHARED_KEY={{ gluetun_wireguard_preshared_key }}
+{% endif %}
+{% if gluetun_wireguard_public_key != 'none' %}
+      - WIREGUARD_PUBLIC_KEY={{ gluetun_wireguard_public_key }}
+{% endif %}
       - WIREGUARD_ADDRESSES={{ gluetun_wireguard_address }}
 {% endif %}
     volumes:


### PR DESCRIPTION
This pull request will enable Wireguard support for Gluetun VPN client and few more configuration options for Gluetun OpenVPN.

Please note, Gluetun Wireguard client is still under testing. It works well, but available with manual configuration only (`webinstall` still don't support it). 