### PR TITLE
to add FW rules for OpenVPN Server upon container start

### DIFF
--- a/templates/openvpn-docker-compose.yml.j2
+++ b/templates/openvpn-docker-compose.yml.j2
@@ -24,6 +24,7 @@ services:
            - ./config:/etc/openvpn/config
            - ./staticclients:/etc/openvpn/staticclients
            - ./log:/var/log/openvpn
+           - ./fw-rules.sh:/opt/app/fw-rules.sh
        cap_add:
            - NET_ADMIN
        restart: always

--- a/templates/openvpn-docker-entrypoint.sh.j2
+++ b/templates/openvpn-docker-entrypoint.sh.j2
@@ -61,6 +61,14 @@ iptables -A FORWARD -p icmp -j DROP --icmp-type echo-reply -s $GUEST_SUB
 echo 'Blocking internal home subnet to access from external openvpn clients (Internet still available)'
 iptables -A FORWARD -s $GUEST_SUB -d $HOME_SUB -j DROP
 
+if [[ ! -s fw-rules.sh ]]; then
+    echo "No additional firewall rules to apply."
+else
+    echo "Applying firewall rules"
+    ./fw-rules.sh
+    echo 'Additional firewall rules applied.'
+fi
+
 echo 'IPT MASQ Chains:'
 iptables -t nat -L | grep MASQ
 echo 'IPT FWD Chains:'


### PR DESCRIPTION
Now you can use fw-rules.sh script to apply additional iptables rules for OpenVPN server container at its startup.