### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Raspberry Gateway Logo](/images/Raspberry-Gateway-logo.png) 
-**Raspberry-Gateway** provides a simple but powerful solution for managing your home internet gateway using a Raspberry Pi. This project includes a range of Docker containers, each serving a specific purpose to enhance your internet experience:
+**Raspberry-Gateway dev branch** provides a simple but powerful solution for managing your home internet gateway using a Raspberry Pi. This project includes a range of Docker containers, each serving a specific purpose to enhance your internet experience:
 
   * [**Portainer**](https://www.portainer.io) a lightweight universal management GUI for all Docker containers which included into this project. 
   * [**Unbound DNS**](https://nlnetlabs.nl/projects/unbound/about/) is the validating, recursive and caching DNS resolver. Designed to be fast and lean.

--- a/templates/openvpn-docker-entrypoint.sh.j2
+++ b/templates/openvpn-docker-entrypoint.sh.j2
@@ -51,7 +51,7 @@ fi
 
 # Listing env parameters:
 echo "Following EASYRSA variables were set during CA init:"
-cat $EASY_RSA/pki/vars | awk '{$1=""; print $0}';
+cat $OPENVPN_DIR/pki/vars | awk '{$1=""; print $0}';
 
 # Configure network
 mkdir -p /dev/net


### PR DESCRIPTION
Bugfix for listing EasyRSA VARs on start.

This was `can't open file` error is  fixed:
```shell
~/openvpn-server $ docker logs openvpn -f
EasyRSA path: /usr/share/easy-rsa OVPN path: /etc/openvpn
cat: can't open '/usr/share/easy-rsa/pki/vars': No such file or directory
PKI already set up.
```

Now it works fine and lists all the parameters:

```shell
 docker logs openvpn -f
EasyRSA path: /usr/share/easy-rsa OVPN path: /etc/openvpn
PKI already set up.
Following EASYRSA variables were set during CA init:
 EASYRSA_DN "org"
 EASYRSA_REQ_COUNTRY "UA"
 EASYRSA_REQ_PROVINCE "KY"
 EASYRSA_REQ_CITY "Kyiv"
 EASYRSA_REQ_ORG "Wonderland"
 EASYRSA_REQ_EMAIL "sweet@wonderland.ua"
 EASYRSA_REQ_OU "Wonderland"
 EASYRSA_REQ_CN "server"
 EASYRSA_KEY_SIZE 2048
 EASYRSA_CA_EXPIRE 3650
 EASYRSA_CERT_EXPIRE 825
 EASYRSA_CERT_RENEW 30
 EASYRSA_CRL_DAYS 180
 Auto generated by OpenVPN-UI v.0.9.3
Configuring networking rules...
```